### PR TITLE
Fix the Markdown example; fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ A Logseq plugin for missing types of fenced code block.
 1. Install this plugin
 2. Activate it
 3. Add a markdown code block to any of your pages like this:
-```
-\`\`\`mermaid
-graph LR
-Apples --> Bannana
-\`\`\`
-```
+   ````markdown
+   ```mermaid
+   graph LR
+   Apples --> Bananas
+   ```
+   ````
 4. Click outside of the code block
 5. Tadaa!
 


### PR DESCRIPTION
In addition, indent the code block so it's a part of list item 3.

Markdown supports guarding a fenced code block with more than 3 backticks, which allows you to document Markdown code using Markdown code:

## Old

**Code**

````markdown
```
\`\`\`mermaid
graph LR
Apples --> Bannana
\`\`\`
```
````

**Rendering**

```
\`\`\`mermaid
graph LR
Apples --> Bannana
\`\`\`
```

## New

**Code**

`````markdown
````markdown
```mermaid
graph LR
Apples --> Bananas
```
````
`````

**Rendering**

````markdown
```mermaid
graph LR
Apples --> Bananas
```
````